### PR TITLE
Add bulk add/remove/read methods using spans.

### DIFF
--- a/src/Nito.Collections.Deque/Deque.cs
+++ b/src/Nito.Collections.Deque/Deque.cs
@@ -967,7 +967,7 @@ namespace Nito.Collections
         /// </summary>
         /// <param name="firstPart">Output variable for the span convering the some initial part of the deque. This may be an empty span.</param>
         /// <param name="secondPart">Output variable for the span convering the rest of the deque. This may be an empty span.</param>
-        public void GetAsSpans(out Span<T> firstPart, out Span<T> secondPart)
+        public void AsSpans(out Span<T> firstPart, out Span<T> secondPart)
         {
             if (_offset + Count < Capacity)
             {

--- a/src/Nito.Collections.Deque/Deque.cs
+++ b/src/Nito.Collections.Deque/Deque.cs
@@ -132,8 +132,22 @@ namespace Nito.Collections
         /// <returns>true if this list is read-only; otherwise, false.</returns>
         bool ICollection<T>.IsReadOnly => false;
 
+        /// <summary>
+        /// Returns the value at the given index, optionally by reference.
+        /// The reference remains valid as long as the element is not removed from the deque.
+        /// </summary>
+        /// <returns>A reference to the value at the given index.</returns>
+        public ref T this[int index]
+        {
+            get
+            {
+                CheckExistingIndexArgument(Count, index);
+                return ref _buffer[DequeIndexToBufferIndex(index)];
+            }
+        }
+
         /// <inheritdoc cref="IList{T}.this" />
-        public T this[int index]
+        T IList<T>.this[int index]
         {
             get
             {
@@ -145,6 +159,16 @@ namespace Nito.Collections
             {
                 CheckExistingIndexArgument(Count, index);
                 DoSetItem(index, value);
+            }
+        }
+
+        /// <inheritdoc cref="IReadOnlyList{T}.this" />
+        T IReadOnlyList<T>.this[int index]
+        {
+            get
+            {
+                CheckExistingIndexArgument(Count, index);
+                return DoGetItem(index);
             }
         }
 

--- a/src/Nito.Collections.Deque/Deque.cs
+++ b/src/Nito.Collections.Deque/Deque.cs
@@ -977,6 +977,32 @@ namespace Nito.Collections
             }
         }
 
+        /// <summary>
+        /// Copies as many elements as possible from the front of the deque to the start of the given span.
+        /// </summary>
+        /// <param name="destination">The destination span, which will receive the elements in front-to-back order.</param>
+        /// <returns>The number of elements copied.</returns>
+        public int CopyFromFrontToSpan(Span<T> destination)
+        {
+            int totalToCopy = Math.Min(Count, destination.Length);
+            if (totalToCopy == 0)
+            {
+                return 0;
+            }
+            if (_offset + totalToCopy < Capacity)
+            {
+                _buffer.AsSpan(_offset, totalToCopy).CopyTo(destination);
+            }
+            else
+            {
+                int fromFirstSpan = Math.Min(totalToCopy, Capacity - _offset);
+                int fromSecondSpan = totalToCopy - fromFirstSpan;
+                _buffer.AsSpan(_offset, fromFirstSpan).CopyTo(destination);
+                _buffer.AsSpan(0, fromSecondSpan).CopyTo(destination.Slice(fromFirstSpan));
+            }
+            return totalToCopy;
+        }
+
 #pragma warning disable CA1812
         [DebuggerNonUserCode]
         private sealed class DebugView

--- a/src/Nito.Collections.Deque/Deque.cs
+++ b/src/Nito.Collections.Deque/Deque.cs
@@ -26,6 +26,7 @@ namespace Nito.Collections
             return new Deque<T>(collection);
         }
 
+#if ENABLE_SPANS
         /// <summary>
         /// Creates a new instance of the <see cref="Deque&lt;T&gt;"/> class with the elements copied from the specified span.
         /// </summary>
@@ -45,6 +46,7 @@ namespace Nito.Collections
                 return new Deque<T>(Deque<T>.DefaultCapacity);
             }
         }
+#endif
     }
 
     /// <summary>
@@ -765,6 +767,7 @@ namespace Nito.Collections
             DoAddToFront(value);
         }
 
+#if ENABLE_SPANS
         /// <summary>
         /// Inserts a span of elements at the back of this deque.
         /// </summary>
@@ -824,6 +827,7 @@ namespace Nito.Collections
                 span.Slice(firstPartLength).CopyTo(_buffer);
             }
         }
+#endif
 
         /// <summary>
         /// Inserts a collection of elements into this deque.
@@ -957,6 +961,7 @@ namespace Nito.Collections
             return result;
         }
 
+#if ENABLE_SPANS
         /// <summary>
         /// Returns two spans that together cover all elements of the deque.
         /// </summary>
@@ -1002,6 +1007,7 @@ namespace Nito.Collections
             }
             return totalToCopy;
         }
+#endif
 
 #pragma warning disable CA1812
         [DebuggerNonUserCode]

--- a/src/Nito.Collections.Deque/Deque.cs
+++ b/src/Nito.Collections.Deque/Deque.cs
@@ -833,14 +833,14 @@ namespace Nito.Collections
         /// </summary>
         /// <param name="span">The elements to copy.</param>
         /// <param name="start">The first buffer index to write to.</param>
-        /// <param name="end">One after the last buffer index to write to. May be less than <paramref name="start"/>.</param>
+        /// <param name="end">One after the last buffer index to write to. Wraps around the end if less than or equal to <paramref name="start"/>.</param>
         private void DoCopyFromSpan(ReadOnlySpan<T> span, int start, int end)
         {
             if (end == 0)
             {
                 end = Capacity;
             }
-            if (start <= end)
+            if (start < end)
             {
                 span.CopyTo(_buffer.AsSpan(start, end - start));
             }

--- a/src/Nito.Collections.Deque/Deque.cs
+++ b/src/Nito.Collections.Deque/Deque.cs
@@ -815,12 +815,12 @@ namespace Nito.Collections
             }
             if (start <= end)
             {
-                span.CopyTo(_buffer.AsSpan().Slice(start, end - start));
+                span.CopyTo(_buffer.AsSpan(start, end - start));
             }
             else
             {
                 int firstPartLength = Capacity - start;
-                span.Slice(0, firstPartLength).CopyTo(_buffer.AsSpan().Slice(start, firstPartLength));
+                span.Slice(0, firstPartLength).CopyTo(_buffer.AsSpan(start, firstPartLength));
                 span.Slice(firstPartLength).CopyTo(_buffer);
             }
         }

--- a/src/Nito.Collections.Deque/Nito.Collections.Deque.csproj
+++ b/src/Nito.Collections.Deque/Nito.Collections.Deque.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <Description>A double-ended queue.</Description>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.0;net461</TargetFrameworks>
     <PackageTags>collection;deque;dequeue</PackageTags>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);ENABLE_SPANS</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/src/Nito.Collections.Deque/Nito.Collections.Deque.csproj
+++ b/src/Nito.Collections.Deque/Nito.Collections.Deque.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A double-ended queue.</Description>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <PackageTags>collection;deque;dequeue</PackageTags>
   </PropertyGroup>
 

--- a/test/UnitTests/DequeUnitTests.cs
+++ b/test/UnitTests/DequeUnitTests.cs
@@ -622,6 +622,15 @@ namespace UnitTests
                     {
                         Assert.Equal(individualDeque[firstPart.Length + i], secondPart[i]);
                     }
+
+                    {
+                        var copyOfFront = new int[rng.Next(2) == 0 ? bulkDeque.Count : rng.Next(bulkDeque.Count * 5 / 4)];
+                        var n = bulkDeque.CopyFromFrontToSpan(copyOfFront);
+                        for (int i = 0; i < n; ++i)
+                        {
+                            Assert.Equal(bulkDeque[i], copyOfFront[i]);
+                        }
+                    }
                 }
             }
         }

--- a/test/UnitTests/DequeUnitTests.cs
+++ b/test/UnitTests/DequeUnitTests.cs
@@ -709,6 +709,20 @@ namespace UnitTests
         }
 
         [Fact]
+        public void GetItem_OptionallyReturnsByReference()
+        {
+            var deque = new Deque<int>(new[] { 1, 2, 3 });
+            ref var r = ref deque[1];
+            r = 20;
+            Assert.Equal(20, deque[1]);
+            Assert.Equal(1, deque.RemoveFromFront());
+            Assert.Equal(20, deque[0]);
+            r = 22;
+            Assert.Equal(22, deque[0]);
+            Assert.Equal(22, deque.RemoveFromFront());
+        }
+
+        [Fact]
         public void GetItem_Split_ReadsElements()
         {
             var deque = new Deque<int>(new[] { 1, 2, 3 });

--- a/test/UnitTests/DequeUnitTests.cs
+++ b/test/UnitTests/DequeUnitTests.cs
@@ -612,7 +612,7 @@ namespace UnitTests
 
                     Span<int> firstPart;
                     Span<int> secondPart;
-                    bulkDeque.GetAsSpans(out firstPart, out secondPart);
+                    bulkDeque.AsSpans(out firstPart, out secondPart);
                     Assert.Equal(bulkDeque.Count, firstPart.Length + secondPart.Length);
                     for (int i = 0; i < firstPart.Length; ++i)
                     {

--- a/test/UnitTests/DequeUnitTests.cs
+++ b/test/UnitTests/DequeUnitTests.cs
@@ -522,6 +522,45 @@ namespace UnitTests
         }
 
         [Fact]
+        public void RepeatedAddToBackFromSpanThenRemoveFromFront()
+        {
+            var deque = new Deque<int>(1);
+            for (int i = 0; i < 20; ++i)
+            {
+                List<int> list = new List<int>();
+                for (int j = 0; j < i; ++j)
+                {
+                    list.Add(j);
+                }
+                deque.AddToBackFromSpan(list.ToArray());
+                for (int j = 0; j < i; ++j)
+                {
+                    Assert.Equal(j, deque.RemoveFromFront());
+                }
+            }
+        }
+
+        [Fact]
+        public void RepeatedAddToFrontFromSpanThenRemoveFromBack()
+        {
+            var deque = new Deque<int>(1);
+            for (int i = 0; i < 20; ++i)
+            {
+                List<int> list = new List<int>();
+                for (int j = 0; j < i; ++j)
+                {
+                    list.Add(j);
+                }
+                list.Reverse();
+                deque.AddToFrontFromSpan(list.ToArray());
+                for (int j = 0; j < i; ++j)
+                {
+                    Assert.Equal(j, deque.RemoveFromBack());
+                }
+            }
+        }
+
+        [Fact]
         public void AddToFrontFromSpan()
         {
             var deque = new Deque<int>(1);

--- a/test/UnitTests/DequeUnitTests.cs
+++ b/test/UnitTests/DequeUnitTests.cs
@@ -1,12 +1,14 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using Nito.Collections;
 using Xunit;
-using System.Collections.Generic;
-using System.Collections;
+
+#pragma warning disable xUnit2013  // "Do not use Assert.Equal() to check for collection size"
 
 namespace UnitTests
 {
-    public class Deque
+    public class DequeUnitTests
     {
         [Fact]
         public void Capacity_SetTo0_ActsLikeList()
@@ -145,6 +147,15 @@ namespace UnitTests
         public void Constructor_FromSequence_InitializesFromSequence()
         {
             var deque = new Deque<int>(new int[] { 1, 2, 3 });
+            Assert.Equal(3, deque.Capacity);
+            Assert.Equal(3, deque.Count);
+            Assert.Equal(new int[] { 1, 2, 3 }, deque);
+        }
+
+        [Fact]
+        public void Constructor_FromSequence_InitializesFromSpan()
+        {
+            var deque = Deque.FromSpan<int>(new int[] { 1, 2, 3 });
             Assert.Equal(3, deque.Capacity);
             Assert.Equal(3, deque.Count);
             Assert.Equal(new int[] { 1, 2, 3 }, deque);
@@ -490,6 +501,129 @@ namespace UnitTests
             deque.InsertRange(1, new[] { 7, 13 });
             Assert.Equal(new[] { 1, 7, 13, 2, 3 }, deque);
             Assert.Equal(5, deque.Capacity);
+        }
+
+        [Fact]
+        public void AddToBackFromSpan()
+        {
+            var deque = new Deque<int>(1);
+            deque.AddToBackFromSpan(new[] { 1, 2, 3 });
+            Assert.Equal(4, deque.Capacity);  // Should have doubled twice
+            Assert.Equal(1, deque.RemoveFromFront());
+            Assert.Equal(2, deque.RemoveFromFront());
+            Assert.Equal(1, deque.Count);
+            deque.AddToBackFromSpan(new[] { 4, 5, 6 });  // Inserts to both ends of the buffer
+            Assert.Equal(4, deque.Count);
+            Assert.Equal(4, deque.Capacity);
+            Assert.Equal(3, deque.RemoveFromFront());
+            Assert.Equal(4, deque.RemoveFromFront());
+            Assert.Equal(5, deque.RemoveFromFront());
+            Assert.Equal(6, deque.RemoveFromFront());
+        }
+
+        [Fact]
+        public void AddToFrontFromSpan()
+        {
+            var deque = new Deque<int>(1);
+            deque.AddToFrontFromSpan(new[] { 4, 5, 6 });
+            Assert.Equal(4, deque.Capacity);  // Should have doubled twice
+            Assert.Equal(6, deque.RemoveFromBack());
+            Assert.Equal(5, deque.RemoveFromBack());
+            Assert.Equal(1, deque.Count);
+            deque.AddToFrontFromSpan(new[] { 1, 2, 3 });  // Inserts to both ends of the buffer
+            Assert.Equal(4, deque.Count);
+            Assert.Equal(4, deque.Capacity);
+            Assert.Equal(4, deque.RemoveFromBack());
+            Assert.Equal(3, deque.RemoveFromBack());
+            Assert.Equal(2, deque.RemoveFromBack());
+            Assert.Equal(1, deque.RemoveFromBack());
+        }
+
+        [Fact]
+        public void Randomized_BulkAddAndRemoveTest()
+        {
+            var rng = new Random(123456789);
+            const int maxOperationSize = 16;
+            int[] GenerateSomeRandomInts()
+            {
+                var n = rng.Next(maxOperationSize);
+                var ints = new int[n];
+                for (int i = 0; i < n; ++i)
+                {
+                    ints[i] = rng.Next(10000);
+                }
+                return ints;
+            }
+
+            for (int repetition = 0; repetition < 50; ++repetition)
+            {
+                var individualDeque = new Deque<int>(0);
+                var bulkDeque = new Deque<int>(0);
+                for (int actionCounter = 0; actionCounter < 100; ++actionCounter)
+                {
+                    int action = rng.Next(4);
+                    switch (action)
+                    {
+                        case 0:
+                            {
+                                var values = GenerateSomeRandomInts();
+                                bulkDeque.AddToBackFromSpan(values);
+                                foreach (var v in values)
+                                {
+                                    individualDeque.AddToBack(v);
+                                }
+                                break;
+                            }
+                        case 1:
+                            {
+                                var values = GenerateSomeRandomInts();
+                                bulkDeque.AddToFrontFromSpan(values);
+                                Array.Reverse(values);
+                                foreach (var v in values)
+                                {
+                                    individualDeque.AddToFront(v);
+                                }
+                                break;
+                            }
+                        case 2:
+                            {
+                                var n = rng.Next(Math.Min(individualDeque.Count, maxOperationSize));
+                                bulkDeque.RemoveFromBack(n);
+                                for (int i = 0; i < n; ++i)
+                                {
+                                    individualDeque.RemoveFromBack();
+                                }
+                                break;
+                            }
+                        case 3:
+                            {
+                                var n = rng.Next(Math.Min(individualDeque.Count, maxOperationSize));
+                                bulkDeque.RemoveFromFront(n);
+                                for (int i = 0; i < n; ++i)
+                                {
+                                    individualDeque.RemoveFromFront();
+                                }
+                                break;
+                            }
+                    }
+
+                    Assert.Equal(individualDeque.Count, bulkDeque.Count);
+                    Assert.Equal(individualDeque, bulkDeque);
+
+                    Span<int> firstPart;
+                    Span<int> secondPart;
+                    bulkDeque.GetAsSpans(out firstPart, out secondPart);
+                    Assert.Equal(bulkDeque.Count, firstPart.Length + secondPart.Length);
+                    for (int i = 0; i < firstPart.Length; ++i)
+                    {
+                        Assert.Equal(individualDeque[i], firstPart[i]);
+                    }
+                    for (int i = 0; i < secondPart.Length; ++i)
+                    {
+                        Assert.Equal(individualDeque[firstPart.Length + i], secondPart[i]);
+                    }
+                }
+            }
         }
 
         [Fact]

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Added factory methods because overloaded constructors taking `(ReadOnlySpan<T> span)` and `(IEnumerable<T> collection)` would be ambiguous given an array.
- This bumps the minimum .NET requirement to .NET Standard 2.1.